### PR TITLE
fix(lib): 1-character tags + disambiguating test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ function prettifyXml(xmlInput, options = {}) {
       if (pad !== 0) {
         pad -= 1
       }
-    } else if (line.match(/^<\w[^>]*[^\/]>.*$/)) {
+    } else if (line.match(/^<\w([^>]*[^\/])?>.*$/)) {
       indent = 1
     } else {
       indent = 0

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -14,6 +14,20 @@ describe('prettifyXml', () => {
     assert(result === output)
   })
 
+  it('single-character long tags', () => {
+    const input = '<p><b><i>foo</i></b><i>bar</i></p>'
+    const output = [
+      '<p>',
+      '  <b>',
+      '    <i>foo</i>',
+      '  </b>',
+      '  <i>bar</i>',
+      '</p>',
+    ].join(EOL)
+    const result = prettifyXml(input)
+    assert(result === output)
+  })
+
   it('takes indent option', () => {
     const input = '<div><p>foo</p><p>bar</p></div>'
     const output = [


### PR DESCRIPTION
Here is a bugfix and new test for issue #1.  The old code doesn't pass the test (indentation is incorrect), but the slight tweak to the regex does.